### PR TITLE
Upgrade lodash to 4.17.21 to fix vulnerabilities (Snyk recommendation)

### DIFF
--- a/vunerable-proj/package.json
+++ b/vunerable-proj/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "express": "4.16.0",
-    "lodash": "4.17.11",
+    "lodash": "4.17.21",
     "jquery": "3.4.0",
     "debug": "2.6.8",
     "morgan": "1.9.0"


### PR DESCRIPTION
This PR upgrades lodash from 4.17.11 to 4.17.21 to address multiple vulnerabilities as recommended by Snyk:
- Regular Expression Denial of Service (ReDoS)
- Code Injection
- Multiple Prototype Pollution issues

See: https://security.snyk.io/vuln/SNYK-JS-LODASH-1018905, https://security.snyk.io/vuln/SNYK-JS-LODASH-1040724, https://security.snyk.io/vuln/SNYK-JS-LODASH-567746, https://security.snyk.io/vuln/SNYK-JS-LODASH-608086, https://security.snyk.io/vuln/SNYK-JS-LODASH-6139239, https://security.snyk.io/vuln/SNYK-JS-LODASH-450202